### PR TITLE
Add onEntityDelete hook to CollectionView

### DIFF
--- a/src/collection/DeleteEntityDialog.tsx
+++ b/src/collection/DeleteEntityDialog.tsx
@@ -14,6 +14,7 @@ export interface DeleteEntityDialogProps<S extends EntitySchema> {
     entity?: Entity<S>,
     schema: S
     open: boolean;
+    afterDelete?: () => void;
     onClose: () => void;
 }
 
@@ -30,7 +31,10 @@ export default function DeleteEntityDialog<S extends EntitySchema>(props: Delete
         if (entity) {
             setOpenSnackbar(true);
             setLoading(true);
-            deleteEntity(entity).then(_ => setLoading(false));
+            deleteEntity(entity).then(_ => {
+                setLoading(false);
+                if(props.afterDelete) props.afterDelete()
+            });
             onClose();
         }
     };

--- a/src/models.ts
+++ b/src/models.ts
@@ -73,6 +73,15 @@ export interface EntityCollectionView<S extends EntitySchema,
      * Properties that can be filtered in this view
      */
     filterableProperties?: Key[];
+
+    /**
+     * Hook called when the user initiates a delete operation.
+     * This is called after the entity is deleted in Firestore.
+     * 
+     * @param collectionPath the Firestore collection path.
+     * @param entity the entity being deleted.
+     */
+    onEntityDelete?(collectionPath: string, entity: Entity<S>): void;
 }
 
 /**
@@ -125,7 +134,6 @@ export interface EntitySchema<Key extends string = string, P extends Properties<
      */
     onPreSave?(entitySaveProps: EntitySaveProps<this>)
         : Promise<EntityValues<this>> | EntityValues<this>
-
 }
 
 /**

--- a/src/routes/CollectionRoute.tsx
+++ b/src/routes/CollectionRoute.tsx
@@ -116,6 +116,7 @@ export function CollectionRoute<S extends EntitySchema>({
             <DeleteEntityDialog entity={deleteEntityClicked}
                                 schema={view.schema}
                                 open={!!deleteEntityClicked}
+                                afterDelete={() => view?.onEntityDelete ? view.onEntityDelete(collectionPath, deleteEntityClicked) : undefined}
                                 onClose={() => setDeleteEntityClicked(undefined)}/>}
 
         </React.Fragment>


### PR DESCRIPTION
We have hooks for pre-save, successful saves, and failed saves, but it doesn't seem like we have a hook for deletions. This PR adds this hook, equivalent to the existing `onEntityDelete` hook on CollectionTable, except it is exposed to the client in EntityCollectionView.