### PR TITLE
Email and password authentication via Firebase UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "codemirror": "^5.58.2",
         "date-fns": "^2.10.0",
         "deep-equal": "^2.0.3",
+        "firebaseui": "^4.7.1",
         "formik": "^2.2.6",
         "material-ui-popup-state": "^1.7.1",
         "object-hash": "^2.0.3",

--- a/src/LoginView.tsx
+++ b/src/LoginView.tsx
@@ -14,7 +14,8 @@ import "firebase/firestore";
 import { useAuthContext } from "./contexts/AuthContext";
 import { useAppConfigContext } from "./contexts/AppConfigContext";
 import { CMSAppProps } from "./CMSAppProps";
-
+import firebase from "firebase";
+import * as firebaseui from "firebaseui";
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -66,6 +67,23 @@ export function LoginView({ skipLoginButtonEnabled, logo }: LoginViewProps) {
         }
     }
 
+    React.useEffect(() => {
+        const ui = firebaseui.auth.AuthUI.getInstance() || new firebaseui.auth.AuthUI(firebase.auth());
+
+        const uiConfig: firebaseui.auth.Config = {
+            callbacks: {
+                signInSuccessWithAuthResult: (authResult, redirectUrl) => true,
+                uiShown: () => authContext.setAuthLoading(false)
+            },
+            signInFlow: 'popup',
+            signInOptions: [
+                // more auth providers can be added here
+                firebase.auth.EmailAuthProvider.PROVIDER_ID
+            ],
+        };
+        ui.start("#firebase-ui", uiConfig);
+    });
+
     return (
         <Grid
             container
@@ -81,11 +99,7 @@ export function LoginView({ skipLoginButtonEnabled, logo }: LoginViewProps) {
                      alt={"Logo"}/>}
             </Box>
 
-            <Button variant="contained"
-                    color="primary"
-                    onClick={authContext.googleSignIn}>
-                Google login
-            </Button>
+            <div id="firebase-ui"></div>
 
             {skipLoginButtonEnabled &&
             <Box m={2}>

--- a/src/LoginView.tsx
+++ b/src/LoginView.tsx
@@ -16,6 +16,7 @@ import { useAppConfigContext } from "./contexts/AppConfigContext";
 import { CMSAppProps } from "./CMSAppProps";
 import firebase from "firebase";
 import * as firebaseui from "firebaseui";
+import "firebaseui/dist/firebaseui.css";
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ interface AuthContextState {
     loggedUser: firebase.User | null;
     authProviderError: any;
     authLoading: boolean;
+    setAuthLoading: React.Dispatch<React.SetStateAction<boolean>>;
     loginSkipped: boolean;
     notAllowedError: boolean;
     googleSignIn: () => void;
@@ -27,6 +28,7 @@ export const AuthContext = React.createContext<AuthContextState>({
     loggedUser: null,
     authProviderError: null,
     authLoading: false,
+    setAuthLoading: () => {},
     loginSkipped: false,
     notAllowedError: false,
     googleSignIn: () => {
@@ -106,6 +108,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = (
                 loggedUser,
                 authProviderError,
                 authLoading,
+                setAuthLoading,
                 loginSkipped,
                 notAllowedError,
                 googleSignIn,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5041,6 +5041,11 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
+dialog-polyfill@^0.4.7:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/dialog-polyfill/-/dialog-polyfill-0.4.10.tgz#c4ea68a0deed4abb59a6a2a025c548b278cd532e"
+  integrity sha512-j5yGMkP8T00UFgyO+78OxiN5vC5dzRQF3BEio+LhNvDbyfxWBsi3sfPArDm54VloaJwy2hm3erEiDWqHRC8rzw==
+
 dicer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.0.tgz#eacd98b3bfbf92e8ab5c2fdb71aaac44bb06b872"
@@ -6259,6 +6264,14 @@ firebase@^7.21.0:
     "@firebase/remote-config" "0.1.28"
     "@firebase/storage" "0.3.43"
     "@firebase/util" "0.3.2"
+
+firebaseui@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/firebaseui/-/firebaseui-4.7.1.tgz#8e0303d9f733e16b0bfbfa24001ab8bd4bc98038"
+  integrity sha512-wDdo3LLnh9sV1dDKyNgn4M7cKecILosvqvtQE1SUum/R+eXLdN1q1ZRKZ2Lp6ZyP0XDAHrotssS4vJNh4OdwuQ==
+  dependencies:
+    dialog-polyfill "^0.4.7"
+    material-design-lite "^1.2.0"
 
 flat-cache@^3.0.4:
   version "3.0.4"
@@ -8853,6 +8866,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+material-design-lite@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/material-design-lite/-/material-design-lite-1.3.0.tgz#d004ce3fee99a1eeb74a78b8a325134a5f1171d3"
+  integrity sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM=
 
 material-ui-popup-state@^1.7.1:
   version "1.7.1"


### PR DESCRIPTION
This PR overrides the original Google login button with Firebase UI. Right now, only the email and password provider is registered, but other providers can be appended in `LoginView.tsx`. AuthContext was modified to expose the setAuthLoading function. 

This is not meant to be merged as-is, because it only includes the email and password provider. I think it's up to the maintainers to determine if they want to proceed with Firebase UI, but I wanted to put this here as a proof of concept. It works well in production with my client.

Have a good day!