### PR TITLE
Add support for custom actions in toolbar

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -109,6 +109,11 @@ export interface EntityCollectionView<S extends EntitySchema = EntitySchema,
      */
     initialFilter?: FilterValues<S>;
 
+    /**
+     * Custom actions to show in the toolbar.
+     * Defaults to none.
+     */
+    customActions?: React.ReactNode[];
 }
 
 /**

--- a/src/routes/CollectionRoute.tsx
+++ b/src/routes/CollectionRoute.tsx
@@ -4,6 +4,7 @@ import { BreadcrumbEntry } from "./navigation";
 import {
     Box,
     Button,
+    ButtonGroup,
     createStyles,
     makeStyles,
     Typography,
@@ -101,13 +102,23 @@ export function CollectionRoute<S extends EntitySchema>({
             </Typography>
         </React.Fragment>
     );
+    
+    const addButton = buildAddEntityButton();
+    
+    let actions: React.ReactNode[] = [];
+    if(view.customActions && view.customActions.length > 0)
+        if(editEnabled) actions = [...view.customActions, addButton];
+        else actions = view.customActions;
+    else if(editEnabled) actions = [addButton];
+
+    const actionGroup = <ButtonGroup>{...actions}</ButtonGroup>
 
     return (
         <div className={classes.root}>
 
             <CollectionTable collectionPath={collectionPath}
                              schema={view.schema}
-                             actions={editEnabled && buildAddEntityButton()}
+                             actions={actionGroup}
                              textSearchDelegate={view.textSearchDelegate}
                              includeToolbar={true}
                              editEnabled={editEnabled}

--- a/src/routes/EntityFormRoute.tsx
+++ b/src/routes/EntityFormRoute.tsx
@@ -11,6 +11,7 @@ import { listenEntity, saveEntity } from "../firebase";
 import {
     Box,
     Button,
+    ButtonGroup,
     createStyles,
     Grid,
     IconButton,
@@ -367,6 +368,23 @@ function EntityFormRoute<S extends EntitySchema>({
             const editEnabled = subcollectionView.editEnabled === undefined || subcollectionView.editEnabled;
             const inlineEditing = editEnabled && (subcollectionView.inlineEditing === undefined || subcollectionView.inlineEditing);
 
+            const addButton = <Button
+                    disabled={!collectionPath}
+                    onClick={onNewClick}
+                    size="medium"
+                    variant="outlined"
+                    color="primary"
+                >
+                    Add {subcollectionView.schema.name}
+                </Button>;
+
+            let actions: React.ReactNode[] = [];
+            if(subcollectionView.customActions && subcollectionView.customActions.length > 0)
+                actions = subcollectionView.customActions;
+            if(editEnabled && !actions.includes(addButton)) actions.push(addButton);
+
+            const actionGroup = <ButtonGroup>{...actions}</ButtonGroup>
+
             return <Box
                 key={`entity_detail_tab_content_${subcollectionView.name}`}
                 role="tabpanel"
@@ -403,17 +421,7 @@ function EntityFormRoute<S extends EntitySchema>({
                                         color={"textSecondary"}>
                                 {`/${collectionPath}`}
                             </Typography>}
-                        actions={
-                            editEnabled && <Button
-                                disabled={!collectionPath}
-                                onClick={onNewClick}
-                                size="medium"
-                                variant="outlined"
-                                color="primary"
-                            >
-                                Add {subcollectionView.schema.name}
-                            </Button>
-                        }
+                        actions={actionGroup}
                         createFormField={createFormField}
                     />
                     :


### PR DESCRIPTION
This addresses issue #22. Adds support for `customActions` array in a collection. You can specify a list of components that will be shown in a ButtonGroup before the Add button in the collection view.


![Screen Shot 2021-01-22 at 8 35 43 PM](https://user-images.githubusercontent.com/6227145/105564725-6a95ad80-5cf1-11eb-9d3a-565b34000d4f.png)