### PR TITLE
Fix firebase peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "algoliasearch": "^4.5.1",
-        "firebase": "^7.21.0 | ^8.0.0",
+        "firebase": "^7.21.0 || ^8.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-scripts": "^4.0.1"


### PR DESCRIPTION
The PR proposes a simple fix for `package.json` regarding peer dependency `firebase`.

Currently, when we use `npm install` (tried 7.6.3), there will be an error regarding unsatisfied versions when the local firebase version is at v8.x. It is caused by the erroneous definition of the firebase version ranges (`range1 || range2`). (See [docs on `package.json`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#dependencies))

