### PR TITLE
Add type safe builder

### DIFF
--- a/example/src/SimpleApp.tsx
+++ b/example/src/SimpleApp.tsx
@@ -5,7 +5,9 @@ import {
     buildCollection,
     buildProperty,
     buildSchema,
+    buildSchemaFromType,
     CMSApp,
+    EntitySchema,
     NavigationBuilder,
     NavigationBuilderProps
 } from "@camberi/firecms";
@@ -140,7 +142,14 @@ const productSchema = buildSchema({
     }
 });
 
-const localeSchema = buildSchema({
+
+type LocalSchema = {
+    title: string,
+    selectable?: boolean,
+    video: string
+}
+
+const localeSchema = buildSchemaFromType<LocalSchema>({
     customId: locales,
     name: "Locale",
     properties: {

--- a/src/models/builders.ts
+++ b/src/models/builders.ts
@@ -1,6 +1,7 @@
 import {
     EntityCollection,
     EntitySchema,
+    EntitySchemaType,
     EntityValues,
     EnumValueConfig,
     PropertiesOrBuilder,
@@ -54,6 +55,17 @@ export function buildSchema<Key extends string = string>(
     schema: EntitySchema<Key>
 ): EntitySchema<Key> {
     return schema;
+}
+
+/**
+ * Identity function that requires a schema that has to have the same 
+ * keys as a provided type
+ * @param schema
+ */
+export function buildSchemaFromType<Type extends EntitySchemaType>(
+    schema: EntitySchema<Extract<keyof Type, string>>
+): EntitySchema<Extract<keyof Type, string>> {
+   return schema;
 }
 
 /**

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -172,6 +172,15 @@ export type ExtraActionsParams<S extends EntitySchema<Key> = EntitySchema<any>,
  */
 export type CollectionSize = "xs" | "s" | "m" | "l" | "xl";
 
+
+export interface EntitySchemaType {
+    [member: string]:
+        undefined | string | number | boolean |
+        string[] | number[] | boolean[] | 
+        EntitySchemaType[] | 
+        EntitySchemaType
+}
+
 /**
  * Specification for defining an entity
  */
@@ -504,8 +513,11 @@ export type PropertyOrBuilder<S extends EntitySchema<Key>, Key extends string = 
     Property<T>
     | PropertyBuilder<S, Key, T>;
 
-export type PropertiesOrBuilder<S extends EntitySchema<Key>, Key extends string = Extract<keyof S["properties"], string>, T extends any = any> =
-    Record<Key, PropertyOrBuilder<S, Key, T>>;
+export type PropertiesOrBuilder<
+    S extends EntitySchema<Key>, 
+    Key extends string = Extract<keyof S["properties"], string>, 
+    T extends any = any
+> = Record<Key, PropertyOrBuilder<S, Key, T>>;
 
 /**
  * This type represents a record of key value pairs as described in an


### PR DESCRIPTION
Partially resolves https://github.com/Camberi/firecms/issues/78.

A very naive attempt to add a type safe builder. This builder guarantees that at the very least, you provide all the fields of your type as schema parameters:

```ts
type LocalSchema = {
    title: string,
    selectable?: boolean,
}

// Compiles
const localeSchema = buildSchemaFromType<LocalSchema>({
    customId: locales,
    name: "Locale",
    properties: {
        title: {
            title: "Title",
            validation: { required: true },
            dataType: "string"
        },
        selectable: {
            title: "Selectable",
            description: "Is this locale selectable",
            dataType: "boolean"
        },
    }
});

//  Object literal may only specify known properties, and 'potato' does not exist in type 
// 'PropertiesOrBuilder<EntitySchema<keyof LocalSchema>, keyof LocalSchema, any>'.
const localeSchema = buildSchemaFromType<LocalSchema>({
    customId: locales,
    name: "Locale",
    properties: {
        potato: {
            title: "Title",
            validation: { required: true },
            dataType: "string"
        },
        selectable: {
            title: "Selectable",
            description: "Is this locale selectable",
            dataType: "boolean"
        },
    }
});

// Property 'title' is missing in type '{ selectable: { title: string; description: string; dataType: "boolean"; }; }' 
// but required in type 'PropertiesOrBuilder<EntitySchema<keyof LocalSchema>, keyof LocalSchema, any>'.
const localeSchema = buildSchemaFromType<LocalSchema>({
    customId: locales,
    name: "Locale",
    properties: {
        selectable: {
            title: "Selectable",
            description: "Is this locale selectable",
            dataType: "boolean"
        },
    }
});
```

This provides a bare minimum type-safety as the actual types are not checked:

```ts
type LocalSchema = {
    title: string,
    selectable?: boolean,
}

// Still compiles despite wrong types for the properties, and missing "required" prop.
const localeSchema = buildSchemaFromType<LocalSchema>({
    customId: locales,
    name: "Locale",
    properties: {
        title: {
            title: "Title",
            dataType: "number"
        },
        selectable: {
            title: "Selectable",
            description: "Is this locale selectable",
            dataType: "string"
        },
    }
});
```

I think this is as far as we can go without completely gutting open the current `EntitySchema` type, and ruining backwards compatibility. 

Let me know what you think!