### PR TITLE
Fix firebase peer dependency version (again) ;)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@material-ui/lab": "^4.0.0-alpha.58",
         "@material-ui/pickers": "^3.3.10",
         "algoliasearch": "^4.9.1",
-        "firebase": "^8.0.0 | ^7.0.0",
+        "firebase": "^8.0.0 || ^7.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "^4.0.3"


### PR DESCRIPTION
The PR proposes a simple fix for `package.json` regarding peer dependency `firebase`.

Currently, when we use `npm install` (tried 7.13.0), there will be an error regarding unsatisfied versions when the local firebase version is at v8.x. It is caused by the erroneous definition of the firebase version ranges (`range1 || range2`). (See [docs on `package.json`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#dependencies))

(Related: #65 :smile:)