### PR TITLE
feature: Access saved entity id in the onSaveSuccess callback

### DIFF
--- a/src/hooks/data/useSaveEntity.ts
+++ b/src/hooks/data/useSaveEntity.ts
@@ -159,7 +159,7 @@ export async function saveEntityWithCallbacks<M>({
                 callbacks.onSaveSuccess({
                     schema,
                     path,
-                    entityId,
+                    entityId: entity.id,
                     values: updatedValues,
                     previousValues,
                     status,


### PR DESCRIPTION
I figured out this would be a nice addition to the onSaveSuccess callback since it's hard to do anything with the given entity if I don't know it's Firestore ID :)

Since functions in Firebase are no longer available in the free tier this will help in adding objects to Algolia on save.

Sample usage: 

```ts
type Organization = {
  name: string;
}
callbacks: buildEntityCallbacks({
  onSaveSuccess: async (props: EntityOnSaveProps<Organization>) => {
    const algoliaObject = {
      ...props.values,
      objectID: props.entityId,
    };
    console.log("Indexing to algolia", algoliaObject);
    await organizationsIndex.partialUpdateObject(algoliaObject, {
      createIfNotExists: true,
    });
  },
  onDelete: async (props) => {
    await organizationsIndex.deleteObject(props.entityId);
  },
}),
```