### PR TITLE
feat: User interface argumentation

### DIFF
--- a/src/models/auth.tsx
+++ b/src/models/auth.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { User } from "./user";
 
 
+export interface AuthControllerExtra {}
+
 /**
  * Controller for retrieving the logged user or performing auth related operations
  * @category Hooks and utilities
@@ -53,7 +55,7 @@ export interface AuthController<UserType extends User = User> {
      * e.g: Additional user data fetched from a Firestore document, or custom
      * claims
      */
-    extra?: any;
+    extra?: AuthControllerExtra;
 
     /**
      * You can use this method to store any extra data you would like to

--- a/src/models/auth.tsx
+++ b/src/models/auth.tsx
@@ -63,7 +63,7 @@ export interface AuthController<UserType extends User = User> {
      * e.g: Additional user data fetched from a Firestore document, or custom
      * claims
      */
-    setExtra: (extra: any) => void;
+    setExtra: (extra: AuthControllerExtra) => void;
 
     /**
      * Delegate in charge of connecting to a backend and performing the auth

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -13,7 +13,7 @@ import { StorageSource } from "./storage";
  *
  * @category Models
  */
-export type User = {
+export interface User {
     /**
      * The user's unique ID, scoped to the project.
      */
@@ -43,7 +43,7 @@ export type User = {
      */
     readonly metadata: any;
 
-} & Record<string, any>; // we allow for any other property so Users can be extended to user needs
+}
 
 
 /**

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -43,7 +43,7 @@ export type User = {
      */
     readonly metadata: any;
 
-} & any; // we allow for any other property so Users can be extended to user needs
+} & Record<string, any>; // we allow for any other property so Users can be extended to user needs
 
 
 /**


### PR DESCRIPTION
```typescript
// types.d.ts

import { User as FirebaseUser } from 'firebase/auth';

declare module '@camberi/firecms' {
  interface User extends FirebaseUser {}
  interface AuthControllerExtra {
    isAdmin: boolean;
  }
}
```

With something like this we can properly type user and extra, if this direction is something that make sense to you. I'll continue on this and add more documentations perhaps.