### PR TITLE
Changed custom Id logic to enable optional custom IDs

### DIFF
--- a/src/form/EntityForm.tsx
+++ b/src/form/EntityForm.tsx
@@ -188,7 +188,7 @@ export function EntityForm<M>({
         previousValues: initialValues
     }), [schemaOrResolver, path, entityId, internalValue]);
 
-    const mustSetCustomId: boolean = (status === "new" || status === "copy") && !!schema.customId;
+    const mustSetCustomId: boolean = (status === "new" || status === "copy") && (!!schema.customId && schema.customId !== "optional");
 
     const underlyingChanges: Partial<EntityValues<M>> = useMemo(() => {
         if (initialValues && status === "existing") {
@@ -225,7 +225,9 @@ export function EntityForm<M>({
             savedEntityId = entity.id;
         } else if (status === "new" || status === "copy") {
             if (schema.customId) {
-                if (!customId) throw Error("Form misconfiguration when saving, customId should be set");
+                if (schema.customId !== "optional" && !customId) {
+                    throw Error("Form misconfiguration when saving, customId should be set");
+                }
                 savedEntityId = customId;
             }
         } else {

--- a/src/models/entities.ts
+++ b/src/models/entities.ts
@@ -19,12 +19,12 @@ export interface EntitySchema<M extends { [Key: string]: any } = any> {
     /**
      * If this property is not set, the property will be created by the
      * datasource.
-     * You can set the value to 'optional' to force the users to choose the ID.
-     * You can set the value to 'allowed' to allow the users to choose the ID. If the ID is empty, an automatic ID will be set.
+     * You can set the value to 'true' to force the users to choose the ID.
+     * You can set the value to 'optional' to allow the users to choose the ID. If the ID is empty, an automatic ID will be set.
      * You can also pass a set of values (as an EnumValues object) to allow them
      * to pick from only those
      */
-    customId?: 'required' | 'optional' | EnumValues;
+    customId?: boolean | "optional" | EnumValues;
 
     /**
      * Set of properties that compose an entity

--- a/src/models/entities.ts
+++ b/src/models/entities.ts
@@ -19,11 +19,12 @@ export interface EntitySchema<M extends { [Key: string]: any } = any> {
     /**
      * If this property is not set, the property will be created by the
      * datasource.
-     * You can set the value to true to allow the users to choose the ID.
+     * You can set the value to 'optional' to force the users to choose the ID.
+     * You can set the value to 'allowed' to allow the users to choose the ID. If the ID is empty, an automatic ID will be set.
      * You can also pass a set of values (as an EnumValues object) to allow them
      * to pick from only those
      */
-    customId?: boolean | EnumValues;
+    customId?: 'required' | 'optional' | EnumValues;
 
     /**
      * Set of properties that compose an entity


### PR DESCRIPTION
🚨🚨 **THIS IS A BREAKING CHANGE!** 🚨🚨

Until now, when a user set `customId: true`, they had to always enter an ID.

This PR introduces new options for the `customId` property. Instead of setting a boolean value, the user selects either `required` or `optional`. If the value is `required`, a custom ID has to be entered (i.e., current behavior). If the value is `optional`, the user can leave the id field empty. In this case, an automatic ID will be used.