### PR TITLE
Introduce customizing / disabling User signups for FirebaseCMSApp

### DIFF
--- a/example/src/SampleApp/SampleApp.tsx
+++ b/example/src/SampleApp/SampleApp.tsx
@@ -223,6 +223,12 @@ function SampleApp() {
         firebaseConfig={firebaseConfig}
         onFirebaseInit={onFirebaseInit}
         toolbarExtraWidget={githubLink}
+        loginViewProps={{
+            noUserComponent: <>An Error has occured. Please contact your admin</>,
+            displaySignupScreen: false,
+        }}
+        
+        
     />;
 }
 

--- a/src/firebase_app/FirebaseCMSApp.tsx
+++ b/src/firebase_app/FirebaseCMSApp.tsx
@@ -61,7 +61,8 @@ export function FirebaseCMSApp({
                                    locale,
                                    HomePage,
                                    basePath,
-                                   baseCollectionPath
+                                   baseCollectionPath,
+                                   noUserComponent
                                }: FirebaseCMSAppProps) {
 
     const {
@@ -134,7 +135,9 @@ export function FirebaseCMSApp({
                                 skipLoginButtonEnabled={allowSkipLogin}
                                 signInOptions={signInOptions ?? DEFAULT_SIGN_IN_OPTIONS}
                                 firebaseApp={firebaseApp}
-                                authDelegate={authDelegate}/>
+                                authDelegate={authDelegate}
+                                noUserComponent={noUserComponent}
+                                />
                         );
                     } else {
                         component = (

--- a/src/firebase_app/FirebaseCMSApp.tsx
+++ b/src/firebase_app/FirebaseCMSApp.tsx
@@ -62,7 +62,7 @@ export function FirebaseCMSApp({
                                    HomePage,
                                    basePath,
                                    baseCollectionPath,
-                                   noUserComponent
+                                    loginViewProps
                                }: FirebaseCMSAppProps) {
 
     const {
@@ -136,7 +136,7 @@ export function FirebaseCMSApp({
                                 signInOptions={signInOptions ?? DEFAULT_SIGN_IN_OPTIONS}
                                 firebaseApp={firebaseApp}
                                 authDelegate={authDelegate}
-                                noUserComponent={noUserComponent}
+                                {...loginViewProps}
                                 />
                         );
                     } else {

--- a/src/firebase_app/FirebaseCMSAppProps.tsx
+++ b/src/firebase_app/FirebaseCMSAppProps.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import {
     Authenticator,
     EntityCollection,
@@ -140,5 +140,10 @@ export interface FirebaseCMSAppProps {
      * Default path under the collection routes of the CMS will be created
      */
     baseCollectionPath?: string;
+
+    /**
+     * UI that will be displayed if user is found to not exist in firebase
+     */
+     noUserComponent?: ReactNode;
 }
 

--- a/src/firebase_app/FirebaseCMSAppProps.tsx
+++ b/src/firebase_app/FirebaseCMSAppProps.tsx
@@ -142,8 +142,11 @@ export interface FirebaseCMSAppProps {
     baseCollectionPath?: string;
 
     /**
-     * UI that will be displayed if user is found to not exist in firebase
+     * Props allowing for minimal firebase login view modifications
      */
-     noUserComponent?: ReactNode;
+     loginViewProps?: {
+        noUserComponent?: ReactNode;
+        displaySignupScreen?: boolean;
+     }
 }
 

--- a/src/firebase_app/components/FirebaseLoginView.tsx
+++ b/src/firebase_app/components/FirebaseLoginView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { ReactNode, useEffect, useRef, useState } from "react";
 
 import {
     Box,
@@ -55,6 +55,7 @@ export interface FirebaseLoginViewProps {
     signInOptions: Array<FirebaseSignInProvider | FirebaseSignInOption>;
     firebaseApp: FirebaseApp;
     authDelegate: FirebaseAuthDelegate
+    noUserComponent?: ReactNode
 }
 
 /**
@@ -68,7 +69,8 @@ export function FirebaseLoginView({
                                       logo,
                                       signInOptions,
                                       firebaseApp,
-                                      authDelegate
+                                      authDelegate,
+                                      noUserComponent
                                   }: FirebaseLoginViewProps) {
     const classes = useStyles();
     const authController = useAuthController();
@@ -204,7 +206,10 @@ export function FirebaseLoginView({
                     {passwordLoginSelected && <LoginForm
                         authDelegate={authDelegate}
                         onClose={() => setPasswordLoginSelected(false)}
-                        mode={modeState.mode}/>}
+                        mode={modeState.mode}
+                        CustomNoUserFound={noUserComponent}
+                        
+                        />}
 
                 </Box>
             </Box>
@@ -253,8 +258,9 @@ function LoginButton({
 function LoginForm({
                        onClose,
                        authDelegate,
-                       mode
-                   }: { onClose: () => void, authDelegate: FirebaseAuthDelegate, mode: "light" | "dark" }) {
+                       mode,
+                       CustomNoUserFound
+                   }: { onClose: () => void, authDelegate: FirebaseAuthDelegate, mode: "light" | "dark", CustomNoUserFound: ReactNode | undefined }) {
 
     const passwordRef = useRef<HTMLInputElement | null>(null);
 
@@ -289,7 +295,10 @@ function LoginForm({
 
     function handleEnterEmail() {
         if (email) {
-            authDelegate.fetchSignInMethodsForEmail(email).then(setAvailableProviders);
+            authDelegate.fetchSignInMethodsForEmail(email).then((availableProviders)=> {
+                console.log(availableProviders);
+                setAvailableProviders(availableProviders)
+            });
         }
     }
 
@@ -384,7 +393,7 @@ function LoginForm({
                                    type="email"
                                    onChange={(event) => setEmail(event.target.value)}/>
                     </Grid>
-
+                    {CustomNoUserFound}
                     <Grid item xs={12}
                           sx={{ display: loginMode || registrationMode ? "inherit" : "none" }}>
                         <TextField placeholder="Password" fullWidth

--- a/src/firebase_app/components/FirebaseLoginView.tsx
+++ b/src/firebase_app/components/FirebaseLoginView.tsx
@@ -55,6 +55,7 @@ export interface FirebaseLoginViewProps {
     signInOptions: Array<FirebaseSignInProvider | FirebaseSignInOption>;
     firebaseApp: FirebaseApp;
     authDelegate: FirebaseAuthDelegate
+    displaySignupScreen?: boolean;
     noUserComponent?: ReactNode
 }
 
@@ -70,7 +71,8 @@ export function FirebaseLoginView({
                                       signInOptions,
                                       firebaseApp,
                                       authDelegate,
-                                      noUserComponent
+                                      noUserComponent,
+                                      displaySignupScreen = true
                                   }: FirebaseLoginViewProps) {
     const classes = useStyles();
     const authController = useAuthController();
@@ -208,7 +210,7 @@ export function FirebaseLoginView({
                         onClose={() => setPasswordLoginSelected(false)}
                         mode={modeState.mode}
                         CustomNoUserFound={noUserComponent}
-                        
+                        displaySignupScreen={displaySignupScreen}
                         />}
 
                 </Box>
@@ -259,8 +261,9 @@ function LoginForm({
                        onClose,
                        authDelegate,
                        mode,
-                       CustomNoUserFound
-                   }: { onClose: () => void, authDelegate: FirebaseAuthDelegate, mode: "light" | "dark", CustomNoUserFound: ReactNode | undefined }) {
+                       CustomNoUserFound,
+                       displaySignupScreen
+                   }: { onClose: () => void, authDelegate: FirebaseAuthDelegate, mode: "light" | "dark", CustomNoUserFound: ReactNode | undefined, displaySignupScreen:boolean }) {
 
     const passwordRef = useRef<HTMLInputElement | null>(null);
 
@@ -380,7 +383,9 @@ function LoginForm({
                         </IconButton>
                     </Grid>
 
-                    <Grid item xs={12} sx={{ p: 1 }}>
+                    <Grid item xs={12} sx={{ p: 1,
+                        display: (registrationMode && !displaySignupScreen) ? "none": "flex",
+                    }}>
                         <Typography align={"center"}
                                     variant={"subtitle2"}>{label}</Typography>
                     </Grid>
@@ -393,9 +398,9 @@ function LoginForm({
                                    type="email"
                                    onChange={(event) => setEmail(event.target.value)}/>
                     </Grid>
-                    {CustomNoUserFound}
+                    {registrationMode && CustomNoUserFound}
                     <Grid item xs={12}
-                          sx={{ display: loginMode || registrationMode ? "inherit" : "none" }}>
+                          sx={{ display: loginMode || (registrationMode && displaySignupScreen) ? "inherit" : "none" }}>
                         <TextField placeholder="Password" fullWidth
                                    value={password}
                                    disabled={authDelegate.authLoading}
@@ -406,7 +411,7 @@ function LoginForm({
 
                     <Grid item xs={12}>
                         <Box sx={{
-                            display: "flex",
+                            display: (registrationMode && !displaySignupScreen) ? "none": "flex",
                             justifyContent: "end",
                             alignItems: "center",
                             width: "100%"


### PR DESCRIPTION
Addresses recent comments on https://github.com/Camberi/firecms/issues/128 - introduces 2 new  nested props to disable and subsequently modify displays when a user is not registered to the CMS yet tries to get access.

```ts
 loginViewProps?: {
        noUserComponent?: ReactNode;
        displaySignupScreen?: boolean;
     }
```


- `noUserComponent` Allows us to introduce some custom react component to customize the feel when a user  does not exist
- `displaySignupScreen` hides the corresponding UIs involving signup.


Given:

```ts
loginViewProps={{
            noUserComponent: <>An Error has occured. Please contact your admin</>,
            displaySignupScreen: false,
        }}
```

it displays:
![image](https://user-images.githubusercontent.com/6106749/156626455-1d2d4511-cd9f-42ae-a86a-b0f059b03f57.png)




