### PR TITLE
fix: when using FirebaseCMSApp with a custom base path

### DIFF
--- a/src/core/internal/useBuildNavigationContext.tsx
+++ b/src/core/internal/useBuildNavigationContext.tsx
@@ -256,8 +256,8 @@ export function useBuildNavigationContext<UserType>({
     const buildUrlCollectionPath = useCallback((path: string): string => `${baseCollectionPath}/${removeInitialAndTrailingSlashes(path)}`,
         [baseCollectionPath]);
 
-    const buildCMSUrlPath = useCallback((path: string): string => cleanBasePath ? `/${cleanBasePath}/${removeInitialAndTrailingSlashes(path)}` : `/${path}`,
-        [cleanBasePath]);
+    const buildCMSUrlPath = useCallback((path: string): string => `/${removeInitialAndTrailingSlashes(path)}`,
+        []);
 
     const onCollectionModifiedForUser = useCallback(<M extends any>(path: string, partialCollection: PartialEntityCollection<M>) => {
         if (userConfigPersistence) {


### PR DESCRIPTION
Fixes a bug where if FirebaseCMSApp is used with a custom base path. E.g. 'admin' all URLs generated for custom nav views have the base path duplicated. I.e. 'admin/admin'

Steps to reproduce.

1. Set up FirebaseCMSApp with a basePath specified.

`<FirebaseCMSApp
        basePath="admin"
        name={'Expressions Fundraising'}
        authentication={myAuthenticator}
        navigation={navigation}
        firebaseConfig={config.firebase}
      />`

2. Define navigation builder like so

`const navigation: NavigationBuilder = async ({
    user,
    authController,
  }: NavigationBuilderProps) => {
    return {
      collections: [...],
      views: [
        {
          path: 'uploads',
          group: 'Admin',
          name: 'Uploads',
          description: 'Manage uploads from here',
          // This can be any React component
          view: <Uploads></Uploads>,
        } as CMSView
      ]
    };
  }
)`

3. The navigation URLs both in the side menu and the cards will be http://localhost:3000/admin/admin/uploads etc.
4. Routing to /admin/admin/uploads doesn't work
5. The routing to /admin/uploads is correct and works
6. Collection URLs are correct and routing works