### PR TITLE
Add "copy url to clipboard" button to ImagePreview

### DIFF
--- a/src/preview/components/ImagePreview.tsx
+++ b/src/preview/components/ImagePreview.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, useMemo, useState } from "react";
 import clsx from "clsx";
-import { IconButton, Theme } from "@mui/material";
+import { IconButton, Theme, Tooltip } from "@mui/material";
+import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 
 import { PreviewSize } from "../../preview";
@@ -33,6 +34,13 @@ const useStyles = makeStyles<Theme, { imageSize: number }>(theme => createStyles
             height: ({ imageSize }) => imageSize,
             borderRadius: "4px",
             maxHeight: "100%"
+        },
+        copyIcon: {
+            borderRadius: "9999px",
+            position: "absolute",
+            bottom: -4,
+            right: 32,
+            backgroundColor: theme.palette.common.white
         },
         previewIcon: {
             borderRadius: "9999px",
@@ -90,17 +98,33 @@ export function ImagePreview({ size, url }: ImagePreviewProps) {
                  style={imageStyle}/>
 
             {onHover && (
-                <a
-                    className={classes.previewIcon}
-                    href={url}
-                    rel="noopener noreferrer"
-                    target="_blank">
-                    <IconButton
-                        size={"small"}
-                        onClick={(e) => e.stopPropagation()}>
-                        <OpenInNewIcon htmlColor={"#666"} fontSize={"small"}/>
-                    </IconButton>
-                </a>
+                <>
+                    <Tooltip title="Copy url to clipboard">
+                        <div className={classes.copyIcon}>
+                            <IconButton
+                                size={"small"}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    navigator.clipboard.writeText(url);
+                                }}>
+                                <ContentPasteIcon htmlColor={"#666"} fontSize={"small"} />
+                            </IconButton>
+                        </div>
+                    </Tooltip>
+                    <Tooltip title="Open image in new tab">
+                        <a
+                            className={classes.previewIcon}
+                            href={url}
+                            rel="noopener noreferrer"
+                            target="_blank">
+                            <IconButton
+                                size={"small"}
+                                onClick={(e) => e.stopPropagation()}>
+                                <OpenInNewIcon htmlColor={"#666"} fontSize={"small"} />
+                            </IconButton>
+                        </a>
+                    </Tooltip>
+                </>
             )}
         </div>
 


### PR DESCRIPTION
This PR adds a button to the ImagePreview component to copy the url of the image when clicked. It also adds a <Tooltip /> to the "open image in new tab" button next to it.

![Small ImagePreview](https://user-images.githubusercontent.com/22575651/159658314-4ba2292a-f79f-4878-b4e0-115ade5b479c.gif)

![Large ImagePreview](https://user-images.githubusercontent.com/22575651/159658329-107f9c23-8f23-479b-9139-4415ae3956b9.gif)

