### PR TITLE
Expose dropzone customization porps

### DIFF
--- a/src/form/fields/StorageUploadField.tsx
+++ b/src/form/fields/StorageUploadField.tsx
@@ -300,7 +300,8 @@ function FileDropComponent({
             accept: storageMeta.acceptedFiles,
             disabled: disabled || isDraggingOver,
             noDragEventsBubbling: true,
-            onDrop: onExternalDrop
+            onDrop: onExternalDrop,
+            ...storageMeta.dropzoneCustomProps
         }
     );
 

--- a/src/models/properties.ts
+++ b/src/models/properties.ts
@@ -649,7 +649,7 @@ export interface StorageMeta {
      * Allowing access to underlying DropZone custom properties
      */
 
-    dropzoneCustomProps: Omit<DropzoneOptions, 'accept' | 'disabled' | 'noDragEventsBubbling' | 'onDrop'>
+    dropzoneCustomProps: Omit<DropzoneOptions, 'accept' | 'disabled' | 'noDragEventsBubbling' | 'onDrop' | 'maxFiles'>
 }
 
 /**

--- a/src/models/properties.ts
+++ b/src/models/properties.ts
@@ -2,6 +2,7 @@ import { FieldProps } from "./fields";
 import { PreviewComponentProps } from "../preview";
 import { ChipColor } from "./colors";
 import { EntityReference, EntityValues, GeoPoint } from "./entities";
+import { DropzoneOptions } from "react-dropzone";
 
 /**
  * @category Entity properties
@@ -642,6 +643,13 @@ export interface StorageMeta {
      * Post process the path
      */
     postProcess?: (pathOrUrl: string) => Promise<string>
+
+    /**
+     * 
+     * Allowing access to underlying DropZone custom properties
+     */
+
+    dropzoneCustomProps: Omit<DropzoneOptions, 'accept' | 'disabled' | 'noDragEventsBubbling' | 'onDrop'>
 }
 
 /**

--- a/website/docs/entities/properties/string.md
+++ b/website/docs/entities/properties/string.md
@@ -39,6 +39,9 @@ indicate that this string refers to a path in Google Cloud Storage.
   disabled, may make the URL unusable and lose the original reference to
   Cloud Storage, so it is not encouraged to use this flag. Defaults to
   false.
+* `postProcess` Async callback to post process resulting file path urls. useful for adding blurhash / metadata.
+* `dropzoneCustomProps` Specific dropzone props that can be used to extend dropzone functionality. [Properties documented here](https://react-dropzone.js.org/#src)
+
 ```tsx
 import { buildProperty } from "./builders";
 


### PR DESCRIPTION
While the default dropzone properties work like a charm out of the box, There could be times where we need to customize it according to our needs, e.g. file size validations, among others!