### PR TITLE
Added warning for NPM users to use Yarn.

### DIFF
--- a/website/docs/quickstart.mdx
+++ b/website/docs/quickstart.mdx
@@ -23,6 +23,10 @@ but it is not compulsory.
 Authentication and authorization are also enabled, and make use of the `extra`
 field in the `authController` to check for permissions.
 
+:::warning
+You MUST use Yarn to install all packages and peer dependencies. Using NPM as your package manager for this projust will throw errors in production.
+:::
+
 #### Create a new React app including Typescript:
 
 ```

--- a/website/versioned_docs/version-1.0.0/quickstart.md
+++ b/website/versioned_docs/version-1.0.0/quickstart.md
@@ -23,6 +23,10 @@ but it is not compulsory.
 Authentication and authorization are also enabled, and make use of the `extra`
 field in the `authController` to check for permissions.
 
+:::warning
+You MUST use Yarn to install all packages and peer dependencies. Using NPM as your package manager for this projust will throw errors in production.
+:::
+
 ### Steps
 
 - Create a new React app including Typescript:


### PR DESCRIPTION

Added a warning on both v1 and Alpha v2 docs for new users setting up to ensure they are using Yarn to install all packages and dependancies. If they do not follow this warning they will see errors in the built production version of the application.

v1 Error: Firebase config returns error for "Illegal App Name (undefined/app)"

v2 Error: Terminal displays "React Not Defined" with the error coming from the React.Fragment call on the home page.