### PR TITLE
fix: remove unnecessary orderBy sort

### DIFF
--- a/lib/src/firebase_app/hooks/useFirestoreDataSource.ts
+++ b/lib/src/firebase_app/hooks/useFirestoreDataSource.ts
@@ -111,14 +111,6 @@ export function useFirestoreDataSource({
                 });
         }
 
-        if (filter && orderBy && order) {
-            Object.entries(filter).forEach(([key, value]) => {
-                if (key !== orderBy) {
-                    queryParams.push(orderByClause(key, "asc"));
-                }
-            });
-        }
-
         if (orderBy && order) {
             queryParams.push(orderByClause(orderBy, order));
         }


### PR DESCRIPTION
## Description
When we want to sort and filter at the same time, it throws an error from Firestore because in the code there is an additional orderBy condition. In this PR I'm removing it. 